### PR TITLE
Added support for auto uncaught exception reporting

### DIFF
--- a/android/UniversalAnalyticsPlugin.java
+++ b/android/UniversalAnalyticsPlugin.java
@@ -28,6 +28,7 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
 
     public static final String SET_USER_ID = "setUserId";
     public static final String DEBUG_MODE = "debugMode";
+    public static final String ENABLE_UNCAUGHT_EXCEPTION_REPORTING = "enableUncaughtExceptionReporting";
 
     public Boolean trackerStarted = false;
     public Boolean debugModeEnabled = false;
@@ -104,6 +105,9 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
             this.setUserId(userId, callbackContext);
         } else if (DEBUG_MODE.equals(action)) {
             this.debugMode(callbackContext);
+        } else if (ENABLE_UNCAUGHT_EXCEPTION_REPORTING.equals(action)) {
+            Boolean enable = args.getBoolean(0);
+            this.enableUncaughtExceptionReporting(enable, callbackContext);
         }
         return false;
     }
@@ -306,5 +310,15 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
 
         tracker.set("&uid", userId);
         callbackContext.success("Set user id" + userId);
+    }
+    
+    private void enableUncaughtExceptionReporting(Boolean enable, CallbackContext callbackContext) {
+        if (! trackerStarted ) {
+            callbackContext.error("Tracker not started");
+            return;
+        }
+
+        tracker.enableExceptionReporting(enable);
+        callbackContext.success((enable ? "Enabled" : "Disabled") + " uncaught exception reporting");
     }
 }

--- a/android/UniversalAnalyticsPlugin.java
+++ b/android/UniversalAnalyticsPlugin.java
@@ -135,8 +135,8 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
     }
 
     private <T> void addCustomDimensionsToHitBuilder(T builder) {
-		//unfortunately the base HitBuilders.HitBuilder class is not public, therefore have to use reflection to use
-		//the common setCustomDimension (int index, String dimension) method
+        //unfortunately the base HitBuilders.HitBuilder class is not public, therefore have to use reflection to use
+        //the common setCustomDimension (int index, String dimension) method
         try {
             Method builderMethod = builder.getClass().getMethod("setCustomDimension", Integer.TYPE, String.class);
 	    	

--- a/android/UniversalAnalyticsPlugin.java
+++ b/android/UniversalAnalyticsPlugin.java
@@ -11,6 +11,8 @@ import org.apache.cordova.CallbackContext;
 import org.json.JSONArray;
 import org.json.JSONException;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map.Entry;
 
@@ -29,7 +31,7 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
 
     public Boolean trackerStarted = false;
     public Boolean debugModeEnabled = false;
-    public HashMap<String, String> customDimensions = new HashMap<String, String>();
+    public HashMap<Integer, String> customDimensions = new HashMap<Integer, String>();
 
     public Tracker tracker;
 
@@ -66,7 +68,7 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
             }
             return true;
         } else if (ADD_DIMENSION.equals(action)) {
-            String key = args.getString(0);
+            Integer key = args.getInt(0);
             String value = args.getString(1);
             this.addCustomDimension(key, value, callbackContext);
             return true;
@@ -117,23 +119,39 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
         }
     }
 
-    private void addCustomDimension(String key, String value, CallbackContext callbackContext) {
-        if (null != key && key.length() > 0 && null != value && value.length() > 0) {
-            customDimensions.put(key, value);
-            callbackContext.success("custom dimension started");
-        } else {
-            callbackContext.error("Expected non-empty string arguments.");
+    private void addCustomDimension(Integer key, String value, CallbackContext callbackContext) {
+        if (key <= 0) {
+            callbackContext.error("Expected positive integer argument for key.");
+            return;
         }
+    	
+        if (null == value || value.length() == 0) {
+            callbackContext.error("Expected non-empty string argument for value.");
+            return;
+        }
+    		
+        customDimensions.put(key, value);
+        callbackContext.success("custom dimension started");
     }
 
-    private void addCustomDimensionsToTracker(Tracker tracker) {
-        for (Entry<String, String> entry : customDimensions.entrySet()) {
-            String key = entry.getKey();
-            String value = entry.getValue();
-            //System.out.println("Setting tracker dimension slot " + key + ": <" + value+">");
-            tracker.send(new HitBuilders
-                    .AppViewBuilder()
-                    .setCustomDimension((Integer.parseInt(key)), value).build());
+    private <T> void addCustomDimensionsToHitBuilder(T builder) {
+		//unfortunately the base HitBuilders.HitBuilder class is not public, therefore have to use reflection to use
+		//the common setCustomDimension (int index, String dimension) method
+        try {
+            Method builderMethod = builder.getClass().getMethod("setCustomDimension", Integer.TYPE, String.class);
+	    	
+            for (Entry<Integer, String> entry : customDimensions.entrySet()) {
+	            Integer key = entry.getKey();
+	            String value = entry.getValue();
+	            try {
+	                builderMethod.invoke(builder, (key), value);
+	            } catch (IllegalArgumentException e) {
+	            } catch (IllegalAccessException e) {
+	            } catch (InvocationTargetException e) {
+	            }
+            }
+        } catch (SecurityException e) {
+        } catch (NoSuchMethodException e) {
         }
     }
 
@@ -143,14 +161,13 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
             return;
         }
 
-        addCustomDimensionsToTracker(tracker);
-
         if (null != screenname && screenname.length() > 0) {
             tracker.setScreenName(screenname);
-            tracker.send(new HitBuilders
-                    .AppViewBuilder()
-                    .build()
-                    );
+            
+            HitBuilders.AppViewBuilder hitBuilder = new HitBuilders.AppViewBuilder();
+            addCustomDimensionsToHitBuilder(hitBuilder);
+            
+            tracker.send(hitBuilder.build());
             callbackContext.success("Track Screen: " + screenname);
         } else {
             callbackContext.error("Expected one non-empty string argument.");
@@ -163,11 +180,11 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
             return;
         }
 
-        addCustomDimensionsToTracker(tracker);
-
         if (null != category && category.length() > 0) {
-            tracker.send(new HitBuilders
-                    .EventBuilder()
+            HitBuilders.EventBuilder hitBuilder = new HitBuilders.EventBuilder();
+            addCustomDimensionsToHitBuilder(hitBuilder);
+            
+            tracker.send(hitBuilder
                     .setCategory(category)
                     .setAction(action)
                     .setLabel(label)
@@ -186,11 +203,11 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
             return;
         }
 
-        addCustomDimensionsToTracker(tracker);
-
         if (null != description && description.length() > 0) {
-            tracker.send(new HitBuilders
-                    .ExceptionBuilder()
+            HitBuilders.ExceptionBuilder hitBuilder = new HitBuilders.ExceptionBuilder();
+            addCustomDimensionsToHitBuilder(hitBuilder);
+        	
+            tracker.send(hitBuilder
                     .setDescription(description)
                     .setFatal(fatal)
                     .build()
@@ -207,11 +224,11 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
             return;
         }
 
-        addCustomDimensionsToTracker(tracker);
-
         if (null != category && category.length() > 0) {
-            tracker.send(new HitBuilders
-                    .TimingBuilder()
+            HitBuilders.TimingBuilder hitBuilder = new HitBuilders.TimingBuilder();
+            addCustomDimensionsToHitBuilder(hitBuilder);
+        	
+            tracker.send(hitBuilder
                     .setCategory(category)
                     .setValue(intervalInMilliseconds)
                     .setVariable(name)
@@ -230,11 +247,11 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
             return;
         }
 
-        addCustomDimensionsToTracker(tracker);
-
         if (null != id && id.length() > 0) {
-            tracker.send(new HitBuilders
-                    .TransactionBuilder()
+            HitBuilders.TransactionBuilder hitBuilder = new HitBuilders.TransactionBuilder();
+            addCustomDimensionsToHitBuilder(hitBuilder);
+        	
+            tracker.send(hitBuilder
                     .setTransactionId(id)
                     .setAffiliation(affiliation)
                     .setRevenue(revenue).setTax(tax)
@@ -254,12 +271,11 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
             return;
         }
 
-        addCustomDimensionsToTracker(tracker);
-
         if (null != id && id.length() > 0) {
+            HitBuilders.ItemBuilder hitBuilder = new HitBuilders.ItemBuilder();
+            addCustomDimensionsToHitBuilder(hitBuilder);
 
-            tracker.send(new HitBuilders
-                    .ItemBuilder()
+            tracker.send(hitBuilder
                     .setTransactionId(id)
                     .setName(name)
                     .setSku(sku)

--- a/ios/UniversalAnalyticsPlugin.h
+++ b/ios/UniversalAnalyticsPlugin.h
@@ -14,6 +14,7 @@
 - (void) startTrackerWithId: (CDVInvokedUrlCommand*)command;
 - (void) setUserId: (CDVInvokedUrlCommand*)command;
 - (void) debugMode: (CDVInvokedUrlCommand*)command;
+- (void) enableUncaughtExceptionReporting: (CDVInvokedUrlCommand*)command;
 - (void) addCustomDimension: (CDVInvokedUrlCommand*)command;
 - (void) trackEvent: (CDVInvokedUrlCommand*)command;
 - (void) trackTiming: (CDVInvokedUrlCommand*)command;

--- a/ios/UniversalAnalyticsPlugin.m
+++ b/ios/UniversalAnalyticsPlugin.m
@@ -67,6 +67,23 @@
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
+- (void) enableUncaughtExceptionReporting: (CDVInvokedUrlCommand*)command
+{
+    CDVPluginResult* pluginResult = nil;
+    
+    if ( ! _trackerStarted) {
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Tracker not started"];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+        return;
+    }
+    
+    bool enabled = [[command.arguments objectAtIndex:0] boolValue];
+    [[GAI sharedInstance] setTrackUncaughtExceptions:enabled];
+    
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
 - (void) addCustomDimension: (CDVInvokedUrlCommand*)command
 {
     CDVPluginResult* pluginResult = nil;

--- a/www/analytics.js
+++ b/www/analytics.js
@@ -63,4 +63,9 @@ UniversalAnalyticsPlugin.prototype.addTransactionItem = function(transactionId, 
   cordova.exec(success, error, 'UniversalAnalytics', 'addTransactionItem', [transactionId, name ,sku, category, price, quantity, currencyCode]);
 };
 
+/* automatic uncaught exception tracking */
+UniversalAnalyticsPlugin.prototype.enableUncaughtExceptionReporting = function (enable, success, error) {
+  cordova.exec(success, error, 'UniversalAnalytics', 'enableUncaughtExceptionReporting', [enable]);
+};
+
 module.exports = new UniversalAnalyticsPlugin();


### PR DESCRIPTION
Added support for automatic uncaught exception reporting, through the
setting of Android's enableExceptionReporting(boolean) and iOS's
setTrackUncaughtExceptions(boolean) methods through a common
enableUncaughtExceptionReporting() plugin method
